### PR TITLE
Fix superfluous --tags

### DIFF
--- a/packages/monorepo-split-github-action/entrypoint.sh
+++ b/packages/monorepo-split-github-action/entrypoint.sh
@@ -84,6 +84,6 @@ then
     if test -z "$TAG_EXISTS_IN_REMOTE"
     then
         git tag $TAG -m "Publishing tag ${TAG}"
-        git push --quiet origin "${TAG}" --tags
+        git push --quiet origin "${TAG}"
     fi
 fi


### PR DESCRIPTION
`git push $REMOTE $REFERENCE`, already includes tag itself as `$REFERENCE`, the `--tags` is therefore superfluous.

https://git-scm.com/docs/git-push:

> `--tags`
> All refs under refs/tags are pushed, in addition to refspecs explicitly listed on the command line.